### PR TITLE
8.0: fixed a few errors, added smsgateway.ca, enable multi partner, added access models permissions

### DIFF
--- a/entity_sms/__init__.py
+++ b/entity_sms/__init__.py
@@ -1,1 +1,1 @@
-import esms, smsglobal, clickatell, controllers
+import esms, smsglobal, clickatell, smsgateway, controllers

--- a/entity_sms/__openerp__.py
+++ b/entity_sms/__openerp__.py
@@ -1,6 +1,6 @@
 {
-    'name': "Entity SMS (CLICKATELL AND SMSGLOBAL)",
-    'version': "1.0",
+    'name': "Entity SMS (SMSGATEWAY,CLICKATELL,SMSGLOBAL)",
+    'version': "1.2",
     'author': "Sythil",
     'category': "Tools",
     'summary': "Allows you send smses from any model",
@@ -8,6 +8,7 @@
         'views/qweb.xml',
         'esms.xml',
         'esms.gateways.csv',
+        'smsgateway/gateway_config.xml',
         'clickatell/gateway_config.xml',
         'smsglobal/gateway_config.xml',
     ],

--- a/entity_sms/__openerp__.py
+++ b/entity_sms/__openerp__.py
@@ -1,6 +1,6 @@
 {
     'name': "Entity SMS (SMSGATEWAY,CLICKATELL,SMSGLOBAL)",
-    'version': "1.3",
+    'version': "1.4",
     'author': "Sythil",
     'category': "Tools",
     'summary': "Allows you send smses from any model",

--- a/entity_sms/__openerp__.py
+++ b/entity_sms/__openerp__.py
@@ -1,6 +1,6 @@
 {
     'name': "Entity SMS (SMSGATEWAY,CLICKATELL,SMSGLOBAL)",
-    'version': "1.2",
+    'version': "1.3",
     'author': "Sythil",
     'category': "Tools",
     'summary': "Allows you send smses from any model",
@@ -8,6 +8,7 @@
         'views/qweb.xml',
         'esms.xml',
         'esms.gateways.csv',
+	'security/ir.model.access.csv',
         'smsgateway/gateway_config.xml',
         'clickatell/gateway_config.xml',
         'smsglobal/gateway_config.xml',

--- a/entity_sms/clickatell/gateway_config.py
+++ b/entity_sms/clickatell/gateway_config.py
@@ -39,7 +39,7 @@ class clickatell_core(models.Model):
         my_field = self.env['ir.model.fields'].search([('name','=',my_field_name)])
         
         if response_code == "SUCCESSFUL":
-            esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'from_mobile':self.env.user.partner_id.mobile, 'to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'gateway_name': gateway_name, 'direction':'O','my_date':datetime.utcnow(), 'status_code':response_code})
+            esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'from_mobile':self.env.user.partner_id.mobile, 'to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'gateway_name': gateway_name, 'direction':'O','my_date':datetime.utcnow(), 'status_code':'successful'})
         
         my_sms_response = sms_response()
         my_sms_response.response_string = response_string.text

--- a/entity_sms/clickatell/gateway_config.py
+++ b/entity_sms/clickatell/gateway_config.py
@@ -17,7 +17,6 @@ class clickatell_core(models.Model):
     def send_sms(self, sms_gateway_id, to_number, sms_content, my_model_name, my_record_id, my_field_name):
         sms_account = self.env['esms.accounts'].search([('id','=',sms_gateway_id)])
        
-        gateway_name = "CLICKATELL"
         format_number = to_number
         if " " in format_number: format_number.replace(" ", "")
         if "+" in format_number: format_number = format_number.replace("+", "")
@@ -39,7 +38,7 @@ class clickatell_core(models.Model):
         my_field = self.env['ir.model.fields'].search([('name','=',my_field_name)])
         
         if response_code == "SUCCESSFUL":
-            esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'from_mobile':self.env.user.partner_id.mobile, 'to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'gateway_name': gateway_name, 'direction':'O','my_date':datetime.utcnow(), 'status_code':'successful'})
+            esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'account_id':sms_account.id,'from_mobile':self.env.user.partner_id.mobile, 'to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'direction':'O','my_date':datetime.utcnow(), 'status_code':'successful'})
         
         my_sms_response = sms_response()
         my_sms_response.response_string = response_string.text

--- a/entity_sms/clickatell/gateway_config.xml
+++ b/entity_sms/clickatell/gateway_config.xml
@@ -9,9 +9,9 @@
       	      <xpath expr="//h2[@string='Gateway Hook']" position="after">
       	          <div attrs="{'invisible': [('gateway_model', '!=', 'esms.clickatell')]}">
 		      <group>
-		          <field name="clickatell_username"/>
-		          <field name="clickatell_password"/>
-		          <field name="clickatell_api_id"/>
+		          <field name="clickatell_username" groups="base.group_erp_manager,base.group_system"/>
+		          <field name="clickatell_password" groups="base.group_erp_manager,base.group_system"/>
+		          <field name="clickatell_api_id" groups="base.group_erp_manager,base.group_system"/>
 	              </group>
     	          </div>
       	      </xpath>

--- a/entity_sms/esms.gateways.csv
+++ b/entity_sms/esms.gateways.csv
@@ -1,3 +1,4 @@
 "gateway_model_name","name"
+"esms.smsgateway","SMSGATEWAY"
 "esms.smsglobal","SMS GLOBAL"
 "esms.clickatell","CLICKATELL"

--- a/entity_sms/esms.py
+++ b/entity_sms/esms.py
@@ -33,7 +33,8 @@ class esms_compose_multi(models.TransientModel):
         for send_to in self._context['active_ids']:
             my_model = self._context['active_model']
             p_mobile = self.env[my_model].search([('id','=',send_to)])[0].mobile
-            my_sms = self.env['esms.core'].send_sms(self.sms_gateway.id, p_mobile, self.sms_content, my_model, send_to, 'mobile')
+	    gateway_model = self.sms_gateway.account_gateway.gateway_model_name
+            my_sms = self.env[gateway_model].send_sms(self.sms_gateway.id, p_mobile, self.sms_content, my_model, send_to, 'mobile')
 
 
 class esms_compose(models.TransientModel):

--- a/entity_sms/esms.py
+++ b/entity_sms/esms.py
@@ -25,7 +25,7 @@ class esms_compose_multi(models.TransientModel):
 
     _name = "esms.compose.multi"
     
-    sms_gateway = fields.Many2one('psms.accounts', required=True, string='Account/Number')
+    sms_gateway = fields.Many2one('esms.accounts', required=True, string='Account/Number')
     sms_content = fields.Text('SMS Content')
     
     @api.one
@@ -63,6 +63,8 @@ class esms_compose(models.TransientModel):
 	   message_return = "Failed to Deliver"
 	elif my_sms.response_code == "SUCCESSFUL":
 	   message_return = "Successful"
+	else:
+	   message_return = "Failed"
 	   
 	if message_return != "Successful":
 	   return {

--- a/entity_sms/esms.py
+++ b/entity_sms/esms.py
@@ -82,6 +82,7 @@ class esms_history(models.Model):
     _name = "esms.history"
     
     record_id = fields.Integer(readonly=True, string="Record")
+    account_id = fields.Many2one('esms.accounts', readonly=True, string="SMS Account")
     model_id = fields.Many2one('ir.model', readonly=True, string="Model")
     model_name = fields.Char(string="Model Name", related='model_id.model', readonly=True)
     field_id = fields.Many2one('ir.model.fields', readonly=True, string="Field")
@@ -91,7 +92,6 @@ class esms_history(models.Model):
     record_name = fields.Char(string="Record Name", compute="_rec_nam")
     status_string = fields.Char(string="Status Code", readonly=True)
     status_code = fields.Selection((('successful', 'Sent'), ('failed', 'Failed to Send'), ('DELIVRD', 'Delivered'), ('EXPIRED','Timed Out'), ('UNDELIV', 'Undelivered')), string='Status Code', readonly=True)
-    gateway_name = fields.Char(string="Gateway Name", readonly=True)
     sms_gateway_message_id = fields.Char(string="SMS Gateway Message ID", readonly=True)
     direction = fields.Selection((("I","INBOUND"),("O","OUTBOUND")), string="Direction", readonly=True)
     my_date = fields.Datetime(string="Date", readonly=True, help="The date and time the sms is received or sent")

--- a/entity_sms/esms.xml
+++ b/entity_sms/esms.xml
@@ -104,7 +104,7 @@
           <field name="name">esms history form view</field>
           <field name="model">esms.history</field>
           <field name="arch" type="xml">
-      	      <form>
+      	      <form create="false" edit="false">
       	          <group>
       	              <field name="my_date"/>
       	              <field name="sms_gateway_message_id"/>
@@ -130,7 +130,7 @@
           <field name="name">esms history tree view</field>
           <field name="model">esms.history</field>
           <field name="arch" type="xml">
-      	      <tree>
+      	      <tree edit="false" create="false">
       	          <field name="create_uid" string="By"/>
       	          <field name="account_id"/>
       	          <field name="record_name"/>
@@ -145,12 +145,25 @@
       </record>
       
       <record model="ir.actions.act_window" id="esms_history_action">
-          <field name="name">esms history action</field>
+          <field name="name">SMS history</field>
           <field name="res_model">esms.history</field>
           <field name="view_type">form</field>
           <field name="view_mode">tree,form</field>
           <field name="help" type="html">
       	      <p class="oe_view_nocontent_create">SMS History</p>
+      	  </field>
+      </record>
+
+      <record model="ir.actions.act_window" id="esms_user_history_action">
+          <field name="name">SMS personal history</field>
+          <field name="res_model">esms.history</field>
+          <field name="view_type">form</field>
+          <field name="view_mode">tree,form</field>
+	  <field name="domain">[('create_uid', '=', uid)]</field>
+          <field name="help" type="html">
+		<p>
+                    This list contains SMS messages sent by you.
+                </p>
       	  </field>
       </record>
       
@@ -159,5 +172,12 @@
       <menuitem id="esms_accounts_menu" name="Accounts" parent="esms_gateway_config_menu" action="esms_action" sequence="90"/>
       <menuitem id="esms_history_menu" name="SMS History" parent="esms_gateway_config_menu" action="esms_history_action" sequence="100"/>
         
+      <menuitem id="esms_user_history_title" name="SMS" parent="mail.mail_feeds_main" groups="base.group_user"/>
+      <record id="esms_user_history_menu" model="ir.ui.menu">
+          <field name="name">SMS History</field>
+          <field name="sequence" eval="10"/>
+          <field name="action" ref="esms_user_history_action"/>
+          <field name="parent_id" ref="esms_user_history_title"/>
+      </record>
   </data>
 </openerp>

--- a/entity_sms/esms.xml
+++ b/entity_sms/esms.xml
@@ -29,7 +29,7 @@
           <field name="arch" type="xml">
       	      <form>
       	          <group>
-      	              <field name="sms_gateway"/>
+      	              <field name="sms_gateway"  widget="selection"/>
       	              <field name="sms_content"/>
       	          </group>
                   <footer>
@@ -46,7 +46,7 @@
       	      <form>
       	          <span style="color:red;font-size:20px;"><field name="error_message"/></span>
       	          <group>
-      	              <field name="sms_gateway"/>
+      	              <field name="sms_gateway" widget="selection"/>
       	              <field name="to_number" />
       	              <field name="sms_content"/>
       	          </group>

--- a/entity_sms/esms.xml
+++ b/entity_sms/esms.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-<!--
+<!-- -->
+
 <act_window name="SMS Multiple Partners"
     res_model="esms.compose.multi"
     src_model="res.partner"
     key2="client_action_multi" 
     view_mode="form" target="new" 
     view_type="form"
+    multi="True"
     id="act_send_sms_partner_multi_menu" />
--->
 
 <act_window name="SMS Partner"
     res_model="esms.compose"

--- a/entity_sms/esms.xml
+++ b/entity_sms/esms.xml
@@ -66,7 +66,7 @@
       	      <form>
       	          <group>
       	              <field name="name"/>
-      	              <field name="account_gateway"/>
+      	              <field name="account_gateway" widget="selection"/>
       	              <field name="priority"/>
       	              <field name="gateway_model" invisible="1"/>
       	          </group>
@@ -107,11 +107,11 @@
       	      <form>
       	          <group>
       	              <field name="my_date"/>
-      	              <field name="gateway_name"/>
       	              <field name="sms_gateway_message_id"/>
-      	              <field name="model_id"/>
+      	              <field name="account_id" options="{'no_open': True}"/>
+      	              <field name="model_id" options="{'no_open': True}"/>
       	              <field name="model_name"/>
-      	              <field name="field_id"/>
+      	              <field name="field_id" options="{'no_open': True}"/>
       	              <field name="record_id"/>
       	              <field name="create_uid"/>
       	              <field name="direction"/>
@@ -132,7 +132,7 @@
           <field name="arch" type="xml">
       	      <tree>
       	          <field name="create_uid" string="By"/>
-      	          <field name="gateway_name"/>
+      	          <field name="account_id"/>
       	          <field name="record_name"/>
       	          <field name="direction"/>
       	          <field name="my_date"/>

--- a/entity_sms/security/ir.model.access.csv
+++ b/entity_sms/security/ir.model.access.csv
@@ -1,0 +1,9 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_esms_accounts_user,access_esms_accounts,model_esms_accounts,base.group_user,1,0,0,0
+access_esms_accounts_system,access_esms_accounts,model_esms_accounts,base.group_system,1,1,1,1
+access_esms_history_user,access_esms_history,model_esms_history,base.group_user,1,0,1,0
+access_esms_history_system,access_esms_history,model_esms_history,base.group_system,1,1,1,1
+access_esms_gateways,access_esms_gateways,model_esms_gateways,,1,0,0,0
+access_esms_smsglobal,access_esms_smsglobal,model_esms_smsglobal,,1,0,0,0
+access_esms_clickatell,access_esms_clickatell,model_esms_clickatell,,1,0,0,0
+access_esms_smsgateway,access_esms_smsgateway,model_esms_smsgateway,,1,0,0,0

--- a/entity_sms/smsgateway/__init__.py
+++ b/entity_sms/smsgateway/__init__.py
@@ -1,0 +1,1 @@
+import gateway_config

--- a/entity_sms/smsgateway/gateway_config.py
+++ b/entity_sms/smsgateway/gateway_config.py
@@ -17,7 +17,6 @@ class smsgateway_core(models.Model):
     def send_sms(self, sms_gateway_id, to_number, sms_content, my_model_name, my_record_id, my_field_name):
         sms_account = self.env['esms.accounts'].search([('id','=',sms_gateway_id)])
 
-        gateway_name = "smsgateway"
         format_number = to_number
         if " " in format_number: format_number.replace(" ", "")
         if "+" in format_number: format_number = format_number.replace("+", "")
@@ -36,7 +35,7 @@ class smsgateway_core(models.Model):
         my_model = self.env['ir.model'].search([('model','=',my_model_name)])
         my_field = self.env['ir.model.fields'].search([('name','=',my_field_name)])
 
-        esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'from_mobile':'','to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'gateway_name': gateway_name, 'direction':'O','my_date':datetime.utcnow(), 'status_code':status_code})
+        esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'account_id':sms_account.id,'from_mobile':'','to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'direction':'O','my_date':datetime.utcnow(), 'status_code':status_code})
 
         my_sms_response = sms_response()
         my_sms_response.response_string = response_string.text

--- a/entity_sms/smsgateway/gateway_config.py
+++ b/entity_sms/smsgateway/gateway_config.py
@@ -36,7 +36,7 @@ class smsgateway_core(models.Model):
         my_model = self.env['ir.model'].search([('model','=',my_model_name)])
         my_field = self.env['ir.model.fields'].search([('name','=',my_field_name)])
 
-        esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'from_mobile':self.env.user.partner_id.mobile,'to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'gateway_name': gateway_name, 'direction':'O','my_date':datetime.utcnow(), 'status_code':status_code})
+        esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'from_mobile':'','to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'gateway_name': gateway_name, 'direction':'O','my_date':datetime.utcnow(), 'status_code':status_code})
 
         my_sms_response = sms_response()
         my_sms_response.response_string = response_string.text

--- a/entity_sms/smsgateway/gateway_config.py
+++ b/entity_sms/smsgateway/gateway_config.py
@@ -1,0 +1,51 @@
+from openerp import models, fields, api
+import logging
+_logger = logging.getLogger(__name__)
+import requests
+from datetime import datetime
+
+class sms_response():
+     response_string = ""
+     response_code = ""
+
+class smsgateway_core(models.Model):
+
+    _name = "esms.smsgateway"
+
+    api_url = fields.Char(string='API URL')
+
+    def send_sms(self, sms_gateway_id, to_number, sms_content, my_model_name, my_record_id, my_field_name):
+        sms_account = self.env['esms.accounts'].search([('id','=',sms_gateway_id)])
+
+        gateway_name = "smsgateway"
+        format_number = to_number
+        if " " in format_number: format_number.replace(" ", "")
+        if "+" in format_number: format_number = format_number.replace("+", "")
+        smsgateway_url = "http://smsgateway.ca/sendsms.aspx?CellNumber=" + format_number + "&MessageBody=" + sms_content + "&AccountKey=" + sms_account.smsgateway_accountkey
+        response_string = requests.get(smsgateway_url)
+
+        response_code = ""
+	status_code = ""
+        if "Message queued successfully" in response_string.text:
+	    status_code = "successful"
+	    response_code = "SUCCESSFUL"
+	else:
+	    status_code = "failed"
+	    response_code = "FAILED DELIVERY"
+
+        my_model = self.env['ir.model'].search([('model','=',my_model_name)])
+        my_field = self.env['ir.model.fields'].search([('name','=',my_field_name)])
+
+        esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'from_mobile':self.env.user.partner_id.mobile,'to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'gateway_name': gateway_name, 'direction':'O','my_date':datetime.utcnow(), 'status_code':status_code})
+
+        my_sms_response = sms_response()
+        my_sms_response.response_string = response_string.text
+        my_sms_response.response_code = response_code
+
+        return my_sms_response
+
+class smsgateway_conf(models.Model):
+
+    _inherit = "esms.accounts"
+
+    smsgateway_accountkey = fields.Char(string='API AccountKey')

--- a/entity_sms/smsgateway/gateway_config.xml
+++ b/entity_sms/smsgateway/gateway_config.xml
@@ -9,7 +9,7 @@
       	      <xpath expr="//h2[@string='Gateway Hook']" position="after">
       	          <div attrs="{'invisible': [('gateway_model', '!=', 'esms.smsgateway')]}">
 		      <group>
-		          <field name="smsgateway_accountkey"/>
+		          <field name="smsgateway_accountkey" groups="base.group_erp_manager,base.group_system"/>
 	              </group>
     	          </div>
       	      </xpath>

--- a/entity_sms/smsgateway/gateway_config.xml
+++ b/entity_sms/smsgateway/gateway_config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+      <record model="ir.ui.view" id="smsgateway_conf_form_view">
+          <field name="name">esms conf form view</field>
+          <field name="model">esms.accounts</field>
+          <field name="inherit_id" ref="entity_sms.esms_conf_form_view"/>
+          <field name="arch" type="xml">
+      	      <xpath expr="//h2[@string='Gateway Hook']" position="after">
+      	          <div attrs="{'invisible': [('gateway_model', '!=', 'esms.smsgateway')]}">
+		      <group>
+		          <field name="smsgateway_accountkey"/>
+	              </group>
+    	          </div>
+      	      </xpath>
+      	  </field>
+      </record>
+  </data>
+</openerp>

--- a/entity_sms/smsglobal/gateway_config.py
+++ b/entity_sms/smsglobal/gateway_config.py
@@ -17,7 +17,6 @@ class smsglobal_core(models.Model):
     def send_sms(self, sms_gateway_id, to_number, sms_content, my_model_name, my_record_id, my_field_name):
         sms_account = self.env['esms.accounts'].search([('id','=',sms_gateway_id)])
        
-        gateway_name = "SMSGLOBAL"
         format_number = to_number
         if " " in format_number: format_number.replace(" ", "")
         if "+" in format_number: format_number = format_number.replace("+", "")
@@ -37,7 +36,7 @@ class smsglobal_core(models.Model):
         my_model = self.env['ir.model'].search([('model','=',my_model_name)])
         my_field = self.env['ir.model.fields'].search([('name','=',my_field_name)])
         if response_code == "SUCCESSFUL":
-            esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'from_mobile':self.env.user.partner_id.mobile,'to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'gateway_name': gateway_name, 'direction':'O','my_date':datetime.utcnow(), 'status_code':'successful', 'sms_gateway_message_id':sms_gateway_message_id})
+            esms_history = self.env['esms.history'].create({'field_id':my_field[0].id, 'record_id': my_record_id,'model_id':my_model[0].id,'account_id':sms_account.id,'from_mobile':self.env.user.partner_id.mobile,'to_mobile':to_number,'sms_content':sms_content,'status_string':response_string.text, 'direction':'O','my_date':datetime.utcnow(), 'status_code':'successful', 'sms_gateway_message_id':sms_gateway_message_id})
         
         my_sms_response = sms_response()
         my_sms_response.response_string = response_string.text

--- a/entity_sms/smsglobal/gateway_config.xml
+++ b/entity_sms/smsglobal/gateway_config.xml
@@ -9,8 +9,8 @@
       	      <xpath expr="//h2[@string='Gateway Hook']" position="after">
       	          <div attrs="{'invisible': [('gateway_model', '!=', 'esms.smsglobal')]}">
 		      <group>
-		          <field name="smsglobal_username"/>
-	                  <field name="smsglobal_password"/>
+		          <field name="smsglobal_username" groups="base.group_erp_manager,base.group_system"/>
+	                  <field name="smsglobal_password" groups="base.group_erp_manager,base.group_system"/>
 	              </group>
     	          </div>
       	      </xpath>

--- a/entity_sms/static/description/index.html
+++ b/entity_sms/static/description/index.html
@@ -1,6 +1,6 @@
 <div style="margin-left:100px;margin-right:100px;">
 <h2>Description</h2>
-Allows you send SMS's using the smsglobal or clickatell gateway<br>
+Allows you send SMS's using the smsglobal,clickatell,smsgateway.ca gateways<br>
 This module only sends smses, it does not yet recieve them<br>
 <br>
 <h2>Features</h2>
@@ -13,7 +13,7 @@ This module only sends smses, it does not yet recieve them<br>
 </ul>
 <h2>Using the module</h2>
 <h3>Initial Configuration</h3>
-1.  Create a smsglobal/clickatell account and add credit<br>
+1.  Create a smsglobal/clickatell/smsgateway account and add credit<br>
 2.  Go to Settings->SMS Gateway Configuration->Accounts and enter the all the api settings<br>
 <br>
 <h3>Sending an SMS to partners / customers / suppliers and leads</h3>


### PR DESCRIPTION
1. Fixed a few errors:
 clickatell/gateway_config.py: status_code has to be successful, not SUCCESSFUL
 esms.py: esms.accounts instead of psms.accounts
 esms.py: message_return has to be always initialized

2. Added a new gateway - smsgateway.ca
Note: always add history even if failed

3. Enable Multi Partner

4. Added access models permissions

5. Hide gateway auth parameters(login,password,key) if not admin.

6. When sending sms sms_gateway field widget="selection"

7. Replaced gateway_name by SMS account in history.

8. Added SMS personal history.

9. Disable manual Create/Import/Edit of SMS history