### PR TITLE
To support Non 'ascii' Characters in erd_maker Module

### DIFF
--- a/erd_maker/erd_maker_module.py
+++ b/erd_maker/erd_maker_module.py
@@ -30,7 +30,7 @@ class ErdMakerModule(models.TransientModel):
         temp_string += "</style>\n"
         
         for keys,values in self.table_dict.items():
-            temp_string += str(values)
+            temp_string += values.encode('utf-8')
         
         self.output_text = temp_string
         


### PR DESCRIPTION
To correct this error

temp_string += str(values)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 2993: ordinal not in range(128)