### PR TITLE
To support Non 'ascii' Characters in erd_maker Module #erd_maker.py file

### DIFF
--- a/erd_maker/erd_maker.py
+++ b/erd_maker/erd_maker.py
@@ -25,7 +25,7 @@ class ErdMaker(models.TransientModel):
         
         temp_string = ""
         for keys,values in self.table_dict.items():
-            temp_string += str(values)
+            temp_string += values.encode('utf-8')
         
         self.output_text = temp_string
         self.table_dict.clear()


### PR DESCRIPTION
To correct this error this time in the other file erd_maker.py line 28

temp_string += str(values)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 2993: ordinal not in range(128)